### PR TITLE
Stop MathJax retries after successful typeset

### DIFF
--- a/components/InteractiveGraph.js
+++ b/components/InteractiveGraph.js
@@ -10,17 +10,29 @@ const InteractiveGraph = ({
   editUrl,
 }) => {
   useEffect(() => {
+    let retryInterval;
+
     const renderMathJax = () => {
       if (typeof window !== 'undefined' && window.MathJax) {
         window.MathJax.typesetPromise()
+          .then(() => {
+            if (retryInterval) {
+              clearInterval(retryInterval);
+              retryInterval = null;
+            }
+          })
           .catch(err => console.error('MathJax typeset error:', err));
       }
     };
 
-    const retryInterval = setInterval(renderMathJax, 500);
+    retryInterval = setInterval(renderMathJax, 500);
     renderMathJax();
 
-    return () => clearInterval(retryInterval);
+    return () => {
+      if (retryInterval) {
+        clearInterval(retryInterval);
+      }
+    };
   }, [description]);
 
   const openNewTab = () => window.open(newTabUrl, "_blank");


### PR DESCRIPTION
## Summary
- clear the MathJax retry interval once typesetting succeeds
- keep a guarded cleanup to avoid leaving the retry loop active on unmount

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69159c5065348323855aae67ad62a55b)